### PR TITLE
Add SwiftUI Peg Solitaire game

### DIFF
--- a/PegSolitaire/Assets.xcassets/Contents.json
+++ b/PegSolitaire/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/PegSolitaire/ContentView.swift
+++ b/PegSolitaire/ContentView.swift
@@ -1,0 +1,210 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var board = Board.standard()
+    @State private var selected: Position? = nil
+    @State private var history: [Board] = []
+    @State private var showGameOver = false
+    @State private var showWin = false
+    @State private var orientationAngle: Angle = .degrees(0)
+
+    var body: some View {
+        GeometryReader { geo in
+            VStack {
+                Spacer()
+                boardView(size: min(geo.size.width, geo.size.height * 0.8))
+                    .rotationEffect(orientationAngle)
+                    .padding()
+                    .background(Color(UIColor.systemBackground))
+                    .onTapGesture {
+                        selected = nil
+                    }
+                Spacer()
+                HStack {
+                    Button(action: undo) {
+                        Image(systemName: "arrow.uturn.backward")
+                            .font(.largeTitle)
+                    }
+                    Spacer()
+                    Button(action: newGame) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.largeTitle)
+                    }
+                }
+                .padding(.horizontal, 40)
+                .padding(.bottom, 30)
+            }
+        }
+        .onAppear {
+            UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+            orientationAngle = angle(for: UIDevice.current.orientation)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            orientationAngle = angle(for: UIDevice.current.orientation)
+        }
+        .alert("Game Over", isPresented: $showGameOver) {
+            Button("New Game", action: newGame)
+            Button("Undo", action: undo)
+        } message: {
+            Text("\(board.pegCount()) pegs left")
+        }
+        .fullScreenCover(isPresented: $showWin) {
+            WinView {
+                newGame()
+            }
+        }
+    }
+
+    func angle(for orientation: UIDeviceOrientation) -> Angle {
+        switch orientation {
+        case .landscapeLeft: return .degrees(90)
+        case .landscapeRight: return .degrees(-90)
+        case .portraitUpsideDown: return .degrees(180)
+        default: return .degrees(0)
+        }
+    }
+
+    func boardView(size: CGFloat) -> some View {
+        let cellSize = size / CGFloat(Board.size)
+        return VStack(spacing: 4) {
+            ForEach(0..<Board.size, id: \.self) { r in
+                HStack(spacing: 4) {
+                    ForEach(0..<Board.size, id: \.self) { c in
+                        cellView(row: r, col: c, cellSize: cellSize)
+                            .frame(width: cellSize, height: cellSize)
+                    }
+                }
+            }
+        }
+        .frame(width: size, height: size)
+        .contentShape(Rectangle())
+    }
+
+    func cellView(row: Int, col: Int, cellSize: CGFloat) -> some View {
+        let pos = Position(row: row, col: col)
+        return Group {
+            switch board.cell(at: pos) {
+            case .invalid:
+                Color.clear
+            case .empty:
+                Circle()
+                    .stroke(Color.primary, lineWidth: 2)
+                    .background(destinationHighlight(pos))
+                    .onTapGesture {
+                        if let sel = selected {
+                            attemptMove(from: sel, to: pos)
+                        }
+                    }
+            case .peg:
+                PegView(isSelected: selected == pos)
+                    .onTapGesture {
+                        handleTap(on: pos)
+                    }
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { _ in
+                                handleTap(on: pos)
+                            }
+                            .onEnded { value in
+                                let threshold = cellSize / 2
+                                let dx = value.translation.width
+                                let dy = value.translation.height
+                                var dest: Position?
+                                if abs(dx) > abs(dy) {
+                                    if dx > threshold { dest = Position(row: row, col: col+2) }
+                                    else if dx < -threshold { dest = Position(row: row, col: col-2) }
+                                } else {
+                                    if dy > threshold { dest = Position(row: row+2, col: col) }
+                                    else if dy < -threshold { dest = Position(row: row-2, col: col) }
+                                }
+                                if let d = dest {
+                                    attemptMove(from: pos, to: d)
+                                }
+                            }
+                    )
+            }
+        }
+    }
+
+    func destinationHighlight(_ pos: Position) -> some View {
+        let dests = selected.map { Set(board.moves(from: $0).map { $0.to }) } ?? []
+        return Group {
+            if dests.contains(pos) {
+                Circle()
+                    .fill(Color.primary.opacity(0.2))
+            } else {
+                Color.clear
+            }
+        }
+    }
+
+    func handleTap(on pos: Position) {
+        if selected == pos {
+            let moves = board.moves(from: pos)
+            if moves.count == 1 {
+                attemptMove(moves[0])
+            } else {
+                selected = nil
+            }
+            return
+        }
+
+        if board.moves(from: pos).isEmpty {
+            selected = nil
+        } else {
+            selected = pos
+        }
+    }
+
+    func attemptMove(_ move: Move) {
+        history.append(board)
+        board.apply(move)
+        selected = nil
+        evaluateGameState()
+    }
+
+    func attemptMove(from: Position, to: Position) {
+        let moves = board.moves(from: from)
+        if let move = moves.first(where: { $0.to == to }) {
+            attemptMove(move)
+        } else if board.moves(from: to).count > 0 {
+            selected = to
+        } else {
+            selected = nil
+        }
+    }
+
+    func undo() {
+        if let last = history.popLast() {
+            board = last
+            selected = nil
+        }
+    }
+
+    func newGame() {
+        board = Board.standard()
+        history = []
+        selected = nil
+        showWin = false
+        showGameOver = false
+    }
+
+    func evaluateGameState() {
+        if board.pegCount() == 1 {
+            showWin = true
+        } else if board.allMoves().isEmpty {
+            showGameOver = true
+        }
+    }
+}
+
+struct PegView: View {
+    var isSelected: Bool
+    var body: some View {
+        Circle()
+            .fill(Color.primary)
+            .overlay(
+                Circle().stroke(Color.primary, lineWidth: isSelected ? 4 : 0)
+            )
+    }
+}

--- a/PegSolitaire/FireworksView.swift
+++ b/PegSolitaire/FireworksView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import UIKit
+
+struct FireworksView: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        FireworksUIView()
+    }
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+class FireworksUIView: UIView {
+    override class var layerClass: AnyClass { CAEmitterLayer.self }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let emitter = self.layer as? CAEmitterLayer else { return }
+        emitter.emitterPosition = CGPoint(x: bounds.midX, y: bounds.maxY)
+        emitter.emitterSize = CGSize(width: bounds.size.width, height: 2)
+        emitter.emitterShape = .line
+        emitter.renderMode = .additive
+
+        let cell = CAEmitterCell()
+        cell.birthRate = 3
+        cell.lifetime = 3.0
+        cell.velocity = 250
+        cell.velocityRange = 100
+        cell.emissionLongitude = -.pi / 2
+        cell.emissionRange = .pi / 4
+        cell.scale = 0.02
+        cell.scaleRange = 0.02
+        cell.contents = UIImage(systemName: "star.fill")?.withTintColor(.systemYellow, renderingMode: .alwaysOriginal).cgImage
+        cell.alphaSpeed = -0.4
+
+        emitter.emitterCells = [cell]
+    }
+}
+
+struct WinView: View {
+    var newGame: () -> Void
+    var body: some View {
+        ZStack {
+            FireworksView()
+                .ignoresSafeArea()
+            VStack(spacing: 20) {
+                Text("Congratulations!")
+                    .font(.largeTitle)
+                    .bold()
+                Button("New Game", action: newGame)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}

--- a/PegSolitaire/GameBoard.swift
+++ b/PegSolitaire/GameBoard.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+struct Position: Hashable {
+    var row: Int
+    var col: Int
+}
+
+enum Cell {
+    case invalid
+    case empty
+    case peg
+}
+
+struct Move: Hashable {
+    let from: Position
+    let over: Position
+    let to: Position
+}
+
+struct Board {
+    private(set) var cells: [[Cell]]
+    static let size = 7
+
+    static func standard() -> Board {
+        var cells = Array(repeating: Array(repeating: Cell.invalid, count: size), count: size)
+        let valid = [
+            [false,false,true,true,true,false,false],
+            [false,false,true,true,true,false,false],
+            [true,true,true,true,true,true,true],
+            [true,true,true,false,true,true,true],
+            [true,true,true,true,true,true,true],
+            [false,false,true,true,true,false,false],
+            [false,false,true,true,true,false,false]
+        ]
+        for r in 0..<size {
+            for c in 0..<size {
+                if valid[r][c] {
+                    cells[r][c] = .peg
+                }
+            }
+        }
+        cells[3][3] = .empty
+        return Board(cells: cells)
+    }
+
+    func cell(at p: Position) -> Cell {
+        guard p.row >= 0 && p.row < Self.size && p.col >= 0 && p.col < Self.size else { return .invalid }
+        return cells[p.row][p.col]
+    }
+
+    func moves(from p: Position) -> [Move] {
+        guard cell(at: p) == .peg else { return [] }
+        var result: [Move] = []
+        let dirs = [(-1,0),(1,0),(0,-1),(0,1)]
+        for d in dirs {
+            let over = Position(row: p.row + d.0, col: p.col + d.1)
+            let dest = Position(row: p.row + 2*d.0, col: p.col + 2*d.1)
+            if cell(at: over) == .peg && cell(at: dest) == .empty {
+                result.append(Move(from: p, over: over, to: dest))
+            }
+        }
+        return result
+    }
+
+    func allMoves() -> [Move] {
+        var result: [Move] = []
+        for r in 0..<Self.size {
+            for c in 0..<Self.size {
+                result.append(contentsOf: moves(from: Position(row: r, col: c)))
+            }
+        }
+        return result
+    }
+
+    mutating func apply(_ move: Move) {
+        cells[move.from.row][move.from.col] = .empty
+        cells[move.over.row][move.over.col] = .empty
+        cells[move.to.row][move.to.col] = .peg
+    }
+
+    func pegCount() -> Int {
+        cells.flatMap { $0 }.filter { if case .peg = $0 { return true } else { return false } }.count
+    }
+}

--- a/PegSolitaire/Info.plist
+++ b/PegSolitaire/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.PegSolitaire</string>
+    <key>CFBundleName</key>
+    <string>PegSolitaire</string>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UIUserInterfaceStyle</key>
+    <string>Automatic</string>
+</dict>
+</plist>

--- a/PegSolitaire/LaunchScreen.storyboard
+++ b/PegSolitaire/LaunchScreen.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17139" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="VC">
+    <devices>
+        <device id="retina6_1" orientation="portrait" appearance="light"/>
+    </devices>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="Scene">
+            <objects>
+                <viewController id="VC" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="view">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FR" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/PegSolitaire/PegSolitaireApp.swift
+++ b/PegSolitaire/PegSolitaireApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct PegSolitaireApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUI Peg Solitaire app for iPhone and iPad
- implement drag-and-drop, move highlighting, undo, and win fireworks
- configure portrait-only orientation and dark/light support

## Testing
- `swiftc PegSolitaire/GameBoard.swift -typecheck`
- `swiftc PegSolitaire/ContentView.swift -typecheck` *(fails: no such module 'SwiftUI')*
- `swiftc PegSolitaire/FireworksView.swift -typecheck` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_689992493944832cb6b2bbd441fbc425