### PR TITLE
Ensure board fits within screen with small border

### DIFF
--- a/PegSolitaire/ContentView.swift
+++ b/PegSolitaire/ContentView.swift
@@ -10,11 +10,13 @@ struct ContentView: View {
 
     var body: some View {
         GeometryReader { geo in
+            let padding: CGFloat = 10
+            let boardSize = min(geo.size.width, geo.size.height * 0.8) - padding * 2
             VStack {
                 Spacer()
-                boardView(size: min(geo.size.width, geo.size.height * 0.8))
+                boardView(size: boardSize)
                     .rotationEffect(orientationAngle)
-                    .padding()
+                    .padding(padding)
                     .background(Color(UIColor.systemBackground))
                     .onTapGesture {
                         selected = nil


### PR DESCRIPTION
## Summary
- Keep game board square and add padding so it fits within available screen space

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68999bc73bec832ca8ad9602c7509f9b