### PR TITLE
Add fade-out animation for removed pegs

### DIFF
--- a/PegSolitaire/ContentView.swift
+++ b/PegSolitaire/ContentView.swift
@@ -167,7 +167,9 @@ struct ContentView: View {
 
     func attemptMove(_ move: Move) {
         history.append(board)
-        board.apply(move)
+        withAnimation(.easeInOut(duration: 0.6)) {
+            board.apply(move)
+        }
         selected = nil
         evaluateGameState()
     }
@@ -215,5 +217,6 @@ struct PegView: View {
             .overlay(
                 Circle().stroke(Color.primary, lineWidth: isSelected ? 4 : 0)
             )
+            .transition(.opacity)
     }
 }


### PR DESCRIPTION
## Summary
- Animate board updates with a 0.6s fade-out when pegs are removed
- Apply opacity transition to PegView for smooth disappearance

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689a279ad42c832c91efcf2907e18be6