### PR TITLE
Swap positions of undo and new game buttons

### DIFF
--- a/PegSolitaire/ContentView.swift
+++ b/PegSolitaire/ContentView.swift
@@ -30,13 +30,13 @@ struct ContentView: View {
                     }
                 Spacer()
                 HStack {
-                    Button(action: undo) {
-                        Image(systemName: "arrow.uturn.backward")
+                    Button(action: newGame) {
+                        Image(systemName: "arrow.clockwise")
                             .font(.largeTitle)
                     }
                     Spacer()
-                    Button(action: newGame) {
-                        Image(systemName: "arrow.clockwise")
+                    Button(action: undo) {
+                        Image(systemName: "arrow.uturn.backward")
                             .font(.largeTitle)
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 -- Click a highlighted destination to move the peg. 
 -- Click outside the board to unfocus the selected peg.
 -- If there is only a single move, clicking the focused peg will move it.
-- Undo button on the bottom left of the screen, featuring the standard undo round arrow.
-- New Game button on the bottom right.
+- New Game button on the bottom left.
+- Undo button on the bottom right of the screen, featuring the standard undo round arrow.
 - When there are no moves left, show a popup with the number of pegs left and two buttons: new game or undo last move.
 - When you win the game, show a screen with congratulations and fireworks in the background. Single button "new game"


### PR DESCRIPTION
## Summary
- swap positions of bottom undo and new game buttons so undo appears on the right
- update documentation to match new button layout

## Testing
- `xcodebuild test -project PegSolitaire.xcodeproj -scheme PegSolitaire` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689a274a6a14832c9adb9c4c5ce8eabd