### PR TITLE
Support multi-step moves with destination highlights

### DIFF
--- a/PegSolitaire/ContentView.swift
+++ b/PegSolitaire/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ContentView: View {
     @State private var board = Board.standard()
     @State private var selected: Position? = nil
+    @State private var multiMovePaths: [Position: [Move]] = [:]
     @State private var history: [Board] = []
     @State private var showGameOver = false
     @State private var showWin = false
@@ -27,6 +28,7 @@ struct ContentView: View {
                     .background(Color(UIColor.systemBackground))
                     .onTapGesture {
                         selected = nil
+                        updateMultiMovePaths()
                     }
                 Spacer()
                 HStack {
@@ -136,7 +138,7 @@ struct ContentView: View {
     }
 
     func destinationHighlight(_ pos: Position) -> some View {
-        let dests = selected.map { Set(board.moves(from: $0).map { $0.to }) } ?? []
+        let dests = Set(multiMovePaths.keys)
         return Group {
             if dests.contains(pos) {
                 Circle()
@@ -149,11 +151,11 @@ struct ContentView: View {
 
     func handleTap(on pos: Position) {
         if selected == pos {
-            let moves = board.moves(from: pos)
-            if moves.count == 1 {
-                attemptMove(moves[0])
+            if multiMovePaths.count == 1, let path = multiMovePaths.values.first {
+                attemptMultiMove(path)
             } else {
                 selected = nil
+                updateMultiMovePaths()
             }
             return
         }
@@ -163,6 +165,7 @@ struct ContentView: View {
         } else {
             selected = pos
         }
+        updateMultiMovePaths()
     }
 
     func attemptMove(_ move: Move) {
@@ -171,24 +174,39 @@ struct ContentView: View {
             board.apply(move)
         }
         selected = nil
+        updateMultiMovePaths()
         evaluateGameState()
     }
 
     func attemptMove(from: Position, to: Position) {
-        let moves = board.moves(from: from)
-        if let move = moves.first(where: { $0.to == to }) {
-            attemptMove(move)
+        if let path = multiMovePaths[to] {
+            attemptMultiMove(path)
         } else if board.moves(from: to).count > 0 {
             selected = to
+            updateMultiMovePaths()
         } else {
             selected = nil
+            updateMultiMovePaths()
         }
+    }
+
+    func attemptMultiMove(_ moves: [Move]) {
+        history.append(board)
+        withAnimation(.easeInOut(duration: 0.6)) {
+            for m in moves {
+                board.apply(m)
+            }
+        }
+        selected = nil
+        updateMultiMovePaths()
+        evaluateGameState()
     }
 
     func undo() {
         if let last = history.popLast() {
             board = last
             selected = nil
+            updateMultiMovePaths()
         }
     }
 
@@ -196,6 +214,7 @@ struct ContentView: View {
         board = Board.standard()
         history = []
         selected = nil
+        updateMultiMovePaths()
         showWin = false
         showGameOver = false
     }
@@ -205,6 +224,14 @@ struct ContentView: View {
             showWin = true
         } else if board.allMoves().isEmpty {
             showGameOver = true
+        }
+    }
+
+    func updateMultiMovePaths() {
+        if let sel = selected {
+            multiMovePaths = board.multiMoveDestinations(from: sel)
+        } else {
+            multiMovePaths = [:]
         }
     }
 }

--- a/PegSolitaire/GameBoard.swift
+++ b/PegSolitaire/GameBoard.swift
@@ -88,4 +88,25 @@ struct Board {
     func pegCount() -> Int {
         cells.flatMap { $0 }.filter { if case .peg = $0 { return true } else { return false } }.count
     }
+
+    func multiMoveDestinations(from start: Position) -> [Position: [Move]] {
+        guard cell(at: start) == .peg else { return [:] }
+        var result: [Position: [Move]] = [:]
+        func dfs(board: Board, pos: Position, path: [Move]) {
+            let moves = board.moves(from: pos)
+            if !path.isEmpty, result[pos] == nil {
+                result[pos] = path
+            }
+            for m in moves {
+                var newBoard = board
+                newBoard.apply(m)
+                var newPath = path
+                newPath.append(m)
+                dfs(board: newBoard, pos: m.to, path: newPath)
+            }
+        }
+        dfs(board: self, pos: start, path: [])
+        result.removeValue(forKey: start)
+        return result
+    }
 }


### PR DESCRIPTION
## Summary
- Compute multi-move destination paths from any peg
- Track and highlight all reachable end positions in the UI
- Execute chained moves when a highlighted destination is tapped

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme PegSolitaire -project PegSolitaire.xcodeproj test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3642f1c4832c9c430e0205f8e2b2