### PR TITLE
Add fade-out animation for removed pegs

### DIFF
--- a/PegSolitaire/ContentView.swift
+++ b/PegSolitaire/ContentView.swift
@@ -167,9 +167,16 @@ struct ContentView: View {
 
     func attemptMove(_ move: Move) {
         history.append(board)
-        board.apply(move)
+        withAnimation(.easeInOut(duration: 0.6)) {
+            board.movePeg(from: move.from, to: move.to)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            withAnimation(.easeInOut(duration: 0.6)) {
+                board.removePeg(at: move.over)
+            }
+            evaluateGameState()
+        }
         selected = nil
-        evaluateGameState()
     }
 
     func attemptMove(from: Position, to: Position) {
@@ -215,5 +222,6 @@ struct PegView: View {
             .overlay(
                 Circle().stroke(Color.primary, lineWidth: isSelected ? 4 : 0)
             )
+            .transition(.opacity)
     }
 }

--- a/PegSolitaire/GameBoard.swift
+++ b/PegSolitaire/GameBoard.swift
@@ -85,6 +85,15 @@ struct Board {
         cells[move.to.row][move.to.col] = .peg
     }
 
+    mutating func movePeg(from: Position, to: Position) {
+        cells[from.row][from.col] = .empty
+        cells[to.row][to.col] = .peg
+    }
+
+    mutating func removePeg(at pos: Position) {
+        cells[pos.row][pos.col] = .empty
+    }
+
     func pegCount() -> Int {
         cells.flatMap { $0 }.filter { if case .peg = $0 { return true } else { return false } }.count
     }


### PR DESCRIPTION
## Summary
- Sequence board updates so moved peg fades before the jumped peg disappears
- Introduce helper methods for moving and removing pegs individually

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689a279ad42c832c91efcf2907e18be6